### PR TITLE
feat: support docker

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,17 +9,3 @@ services:
     restart: unless-stopped
     ports:
       - "5173:5173"
-    volumes:
-      # Mount the local frontend directory into the container
-      # This allows for hot-reloading when you change files
-      - ./frontend:/app/frontend
-      # Use a volume for node_modules to prevent it from being overwritten
-      # by the local empty node_modules directory.
-      - /app/frontend/node_modules
-    environment:
-      # Prevent to open browser when starting.
-      - IS_DOCKER=true
-      # This helps ensure file changes are detected correctly for hot-reloading in Docker.
-      - WATCHPACK_POLLING=true
-      # Add other hosts you wish to access from. Separate them with commas (,).
-      - ALLOWED_HOSTS=localhost,dev.arisutalk.moe

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,7 @@ services:
       context: .
       dockerfile: frontend/Dockerfile
     container_name: arisutalk-frontend
+    restart: unless-stopped
     ports:
       - "5173:5173"
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,24 @@
+version: '3.8'
+
+services:
+  frontend:
+    build:
+      context: .
+      dockerfile: frontend/Dockerfile
+    container_name: arisutalk-frontend
+    ports:
+      - "5173:5173"
+    volumes:
+      # Mount the local frontend directory into the container
+      # This allows for hot-reloading when you change files
+      - ./frontend:/app/frontend
+      # Use a volume for node_modules to prevent it from being overwritten
+      # by the local empty node_modules directory.
+      - /app/frontend/node_modules
+    environment:
+      # Prevent to open browser when starting.
+      - IS_DOCKER=true
+      # This helps ensure file changes are detected correctly for hot-reloading in Docker.
+      - WATCHPACK_POLLING=true
+      # Add other hosts you wish to access from. Separate them with commas (,).
+      - ALLOWED_HOSTS=localhost,dev.arisutalk.moe

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,32 @@
+# Use the official Node.js 22 alpine image
+FROM node:22-alpine
+
+# Install pnpm globally
+RUN npm install -g pnpm
+
+# Set the working directory in the container
+WORKDIR /app
+
+# Copy workspace configuration
+COPY pnpm-workspace.yaml .
+
+# Copy package.json and pnpm-lock.yaml for the frontend
+COPY frontend/package.json frontend/pnpm-lock.yaml ./frontend/
+
+# Install dependencies for the frontend
+RUN cd frontend && pnpm install
+
+# Copy the rest of the frontend source code
+COPY frontend/ ./frontend/
+
+# Expose the port Vite runs on
+EXPOSE 5173
+
+# Set the working directory to the frontend folder
+WORKDIR /app/frontend
+
+# Set the environment variable to indicate we are in a Docker container
+ENV IS_DOCKER=true
+
+# The command to start the development server
+CMD ["pnpm", "dev", "--host"]

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,32 +1,37 @@
-# Use the official Node.js 22 alpine image
-FROM node:22-alpine
+# Use the official Node.js 22 image
+FROM node:22-slim AS builder
 
 # Install pnpm globally
-RUN npm install -g pnpm
+# https://pnpm.io/docker
+ENV PNPM_HOME="/pnpm"
+ENV PATH="$PNPM_HOME:$PATH"
+RUN corepack enable
 
 # Set the working directory in the container
 WORKDIR /app
 
 # Copy workspace configuration
-COPY pnpm-workspace.yaml .
+COPY pnpm-workspace.yaml pnpm-lock.yaml package.json .
 
-# Copy package.json and pnpm-lock.yaml for the frontend
-COPY frontend/package.json frontend/pnpm-lock.yaml ./frontend/
+# Copy package.json for the frontend
+COPY frontend/package.json ./frontend/
 
-# Install dependencies for the frontend
-RUN cd frontend && pnpm install
+# Install dependencies for the frontend.
+# Since pnpm is used by only frontend, it will install frontend dependency only.
+RUN pnpm install
 
 # Copy the rest of the frontend source code
 COPY frontend/ ./frontend/
 
-# Expose the port Vite runs on
+# Let's build!
+RUN pnpm run build:fe
+
+# --------------------------------------------------------------
+FROM joseluisq/static-web-server:2
+
+# Copy dist static files
+COPY --from=builder /app/frontend/dist /public
+
 EXPOSE 5173
 
-# Set the working directory to the frontend folder
-WORKDIR /app/frontend
-
-# Set the environment variable to indicate we are in a Docker container
-ENV IS_DOCKER=true
-
-# The command to start the development server
-CMD ["pnpm", "dev", "--host"]
+CMD ["--port", "5173", "--root", "/public"]

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -3,9 +3,7 @@ import { VitePWA } from "vite-plugin-pwa";
 
 export default defineConfig({
     server: {
-        allowedHosts: process.env.ALLOWED_HOSTS?.split(","),
-        // in a Docker environment, browser will not open.
-        open: process.env.IS_DOCKER ? false : "index.html",
+        open: "index.html",
     },
     build: {
         outDir: "dist",

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -3,7 +3,9 @@ import { VitePWA } from "vite-plugin-pwa";
 
 export default defineConfig({
     server: {
-        open: "index.html",
+        allowedHosts: process.env.ALLOWED_HOSTS?.split(","),
+        // in a Docker environment, browser will not open.
+        open: process.env.IS_DOCKER ? false : "index.html",
     },
     build: {
         outDir: "dist",


### PR DESCRIPTION
## Description
- To easy self-hosting, I've configured the project for easy Docker container deployment.
- Simply execute `docker compose up` in the root directory to launch the container.

### Changelog
- add docker-compose.yml
- add frontent/Dockerfile
- add allowedHosts to frontend/vite.config.ts
- prevent to open browser in docker environment

### Details
- When app runs, it attempts to open a browser, but this causes an error in a Docker environment because no browser is present.
  - Code to prevent this issue has been added to `frontend/vite.config.ts`
- Since I'm unaware of the production([dev.arisutalk.moe/](http://dev.arisutalk.moe/)) deployment strategy, I've configured allowedHost directly in `frontend/vite.config.ts`.
  - Should a more optimal method be suggested, I am open to making revisions.

tmi. I'm not very familiar with Vite, so I used AI to help with this work (especially the Dockerfile).

## Checklist

If these questions do not apply to your pull request, just check them.

- [X] I have tested my changes locally.
  - I tested this on my local machine and an Oracle A1 instance.
- [ ] I have updated the documentation...
- [ ] and docstrings(JSDoc or KDoc).
- [X] I've also checked the code for any linting error/warnings.
- [ ] I formatted the code with the formatter.

## Additional Notes

Add any other context or screenshots here.
