### PR TITLE
feat(mobile): Implement long-press to edit characters with refined UX

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -8,7 +8,8 @@
   <!-- Temporary transparent icon to prevent 404 errors -->
   <link rel="icon" href="/icon_192.png" />
   <script src="https://cdn.tailwindcss.com"></script>
-  <link rel="stylesheet" href="/index.css" />
+  <link rel="stylesheet" href="/css/main.css" />
+  <link rel="stylesheet" href="/css/animations.css" />
 </head>
 
 <body class="bg-gray-950 text-white">

--- a/frontend/src/components/CharacterListPage.js
+++ b/frontend/src/components/CharacterListPage.js
@@ -165,7 +165,7 @@ export function renderCharacterListPage(app) {
   let longPressFired = false;
   let isTouching = false; // Flag to distinguish touch from mouse events
 
-  const handleLongPress = (item, e) => {
+  function handleLongPress(item, e) {
     longPressTimer = null;
     longPressFired = true;
 
@@ -184,9 +184,9 @@ export function renderCharacterListPage(app) {
         ripple.remove();
         app.openCharacterEditMode(characterId);
     }, RIPPLE_ANIMATION_DURATION_MS);
-  };
+  }
 
-  const handlePressStart = (e, isTouchEvent) => {
+  function handlePressStart(e, isTouchEvent) {
     const item = e.target.closest(".character-list-item");
     if (!item) return;
 
@@ -198,19 +198,19 @@ export function renderCharacterListPage(app) {
     touchStartY = point.clientY;
     
     longPressTimer = setTimeout(() => handleLongPress(item, e), LONG_PRESS_DURATION_MS);
-  };
+  }
 
-  const handlePressEnd = () => {
+  function handlePressEnd() {
     clearTimeout(longPressTimer);
-  };
+  }
 
-  const handlePressMove = (e, isTouchEvent) => {
+  function handlePressMove(e, isTouchEvent) {
     if (!longPressTimer) return;
     const point = isTouchEvent ? e.touches[0] : e;
     if (Math.abs(point.clientX - touchStartX) > TOUCH_MOVE_THRESHOLD_PX || Math.abs(point.clientY - touchStartY) > TOUCH_MOVE_THRESHOLD_PX) {
       clearTimeout(longPressTimer);
     }
-  };
+  }
 
   listContainer.addEventListener("click", (e) => {
     const item = e.target.closest(".character-list-item");

--- a/frontend/src/components/CharacterListPage.js
+++ b/frontend/src/components/CharacterListPage.js
@@ -2,6 +2,10 @@ import { t } from "../i18n.js";
 import { renderAvatar } from "./Avatar.js";
 import { formatTimestamp } from "../utils.js";
 
+const LONG_PRESS_DURATION_MS = 500;
+const RIPPLE_EFFECT_DURATION_MS = 600;
+const TOUCH_MOVE_THRESHOLD_PX = 10;
+
 /**
  * Renders a single character item for the character list page.
  * @param {object} app - The main application object.
@@ -208,9 +212,9 @@ export function renderCharacterListPage(app) {
       setTimeout(() => {
           ripple.remove();
           app.openCharacterEditMode(characterId);
-      }, 600);
+      }, RIPPLE_EFFECT_DURATION_MS);
 
-    }, 500);
+    }, LONG_PRESS_DURATION_MS);
   }, { passive: true });
 
   listContainer.addEventListener("touchend", (e) => {
@@ -218,7 +222,7 @@ export function renderCharacterListPage(app) {
   });
 
   listContainer.addEventListener("touchmove", (e) => {
-    if (longPressTimer && (Math.abs(e.touches[0].clientX - touchStartX) > 10 || Math.abs(e.touches[0].clientY - touchStartY) > 10)) {
+    if (longPressTimer && (Math.abs(e.touches[0].clientX - touchStartX) > TOUCH_MOVE_THRESHOLD_PX || Math.abs(e.touches[0].clientY - touchStartY) > TOUCH_MOVE_THRESHOLD_PX)) {
       clearTimeout(longPressTimer);
     }
   });

--- a/frontend/src/components/CharacterListPage.js
+++ b/frontend/src/components/CharacterListPage.js
@@ -217,22 +217,24 @@ export function renderCharacterListPage(app) {
 
     const characterId = Number(item.dataset.characterId);
 
-    if (longPressFired) {
+    if (longPressFired || app.state.mobileEditModeCharacterId !== null) {
       e.preventDefault();
       e.stopPropagation();
-      longPressFired = false;
-      return;
-    }
-    if (app.state.mobileEditModeCharacterId !== null) {
-      e.preventDefault();
-      e.stopPropagation();
+      if (longPressFired) {
+        longPressFired = false;
+      }
       return;
     }
     app.handleCharacterSelect(characterId, e);
   });
 
   listContainer.addEventListener("contextmenu", (e) => {
+    const item = e.target.closest(".character-list-item");
+    if (!item) return;
+
     e.preventDefault();
+    const characterId = Number(item.dataset.characterId);
+    app.openCharacterEditMode(characterId);
   });
 
   // Touch events

--- a/frontend/src/components/CharacterListPage.js
+++ b/frontend/src/components/CharacterListPage.js
@@ -251,10 +251,12 @@ export function renderCharacterListPage(app) {
     isTouching = true;
     handlePressStart(e, true);
   }, { passive: true });
-  listContainer.addEventListener("touchend", () => {
+  const onTouchEnd = () => {
     isTouching = false;
     handlePressEnd();
-  });
+  };
+  listContainer.addEventListener("touchend", onTouchEnd);
+  listContainer.addEventListener("touchcancel", onTouchEnd);
   listContainer.addEventListener("touchmove", (e) => handlePressMove(e, true));
 
   // Mouse events

--- a/frontend/src/components/CharacterModal.js
+++ b/frontend/src/components/CharacterModal.js
@@ -123,7 +123,7 @@ export function renderCharacterModal(app) {
 
   return `
         <div id="character-modal-backdrop" class="fixed inset-0 bg-black/60 flex items-center justify-center z-50 p-4 transition-all duration-300 ease-out">
-            <div class="bg-gray-800 rounded-2xl w-full max-w-md mx-auto my-auto flex flex-col" style="max-height: 90vh;">
+            <div id="character-modal-panel" class="bg-gray-800 rounded-2xl w-full max-w-md mx-auto my-auto flex flex-col" style="max-height: 90vh;">
                 <div class="flex items-center justify-between px-6 py-2 md:p-6 border-b border-gray-700 shrink-0">
                     <h3 class="text-xl font-semibold text-white">${
                       isNew

--- a/frontend/src/components/CharacterModal.js
+++ b/frontend/src/components/CharacterModal.js
@@ -124,13 +124,13 @@ export function renderCharacterModal(app) {
   return `
         <div id="character-modal-backdrop" class="fixed inset-0 bg-black/60 flex items-center justify-center z-50 p-4 transition-all duration-300 ease-out">
             <div class="bg-gray-800 rounded-2xl w-full max-w-md mx-auto my-auto flex flex-col" style="max-height: 90vh;">
-                <div class="flex items-center justify-between p-6 border-b border-gray-700 shrink-0">
+                <div class="flex items-center justify-between px-6 py-2 md:p-6 border-b border-gray-700 shrink-0">
                     <h3 class="text-xl font-semibold text-white">${
                       isNew
                         ? t("characterModal.addContact")
                         : t("characterModal.editContact")
                     }</h3>
-                    <button id="close-character-modal" data-action="close-character-modal" class="p-1 hover:bg-gray-700 rounded-full"><i data-lucide="x" class="w-5 h-5"></i></button>
+                    <button id="close-character-modal" data-action="close-character-modal" class="p-3 md:p-1 hover:bg-gray-700 rounded-full"><i data-lucide="x" class="w-7 h-7 md:w-5 md:h-5"></i></button>
                 </div>
                 <div class="p-6 space-y-6 overflow-y-auto">
                     <div class="flex items-center space-x-4">

--- a/frontend/src/components/CharacterModal.js
+++ b/frontend/src/components/CharacterModal.js
@@ -122,7 +122,7 @@ export function renderCharacterModal(app) {
   };
 
   return `
-        <div id="character-modal-backdrop" class="fixed inset-0 bg-black/60 backdrop-blur-sm flex items-center justify-center z-50 p-4">
+        <div id="character-modal-backdrop" class="fixed inset-0 bg-black/60 flex items-center justify-center z-50 p-4 transition-all duration-300 ease-out">
             <div class="bg-gray-800 rounded-2xl w-full max-w-md mx-auto my-auto flex flex-col" style="max-height: 90vh;">
                 <div class="flex items-center justify-between p-6 border-b border-gray-700 shrink-0">
                     <h3 class="text-xl font-semibold text-white">${

--- a/frontend/src/components/CharacterModal.js
+++ b/frontend/src/components/CharacterModal.js
@@ -122,7 +122,7 @@ export function renderCharacterModal(app) {
   };
 
   return `
-        <div class="fixed inset-0 bg-black/60 backdrop-blur-sm flex items-center justify-center z-50 p-4">
+        <div id="character-modal-backdrop" class="fixed inset-0 bg-black/60 backdrop-blur-sm flex items-center justify-center z-50 p-4">
             <div class="bg-gray-800 rounded-2xl w-full max-w-md mx-auto my-auto flex flex-col" style="max-height: 90vh;">
                 <div class="flex items-center justify-between p-6 border-b border-gray-700 shrink-0">
                     <h3 class="text-xl font-semibold text-white">${

--- a/frontend/src/handlers/modalHandlers.js
+++ b/frontend/src/handlers/modalHandlers.js
@@ -31,7 +31,7 @@ export function handleModalClick(e, app) {
 
   // Character Modal
   if (e.target.closest("#open-new-character-modal-mobile"))
-    app.openNewCharacterModal();
+    app.openNewCharacterModal(e);
 
   // Prompt Modal
   if (e.target.closest("#open-prompt-modal"))

--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -1509,6 +1509,13 @@ class PersonaChatApp {
       selectedStickerIndices: [],
       modalOpeningEvent: e,
     });
+
+    requestAnimationFrame(() => {
+      const modalBackdrop = document.getElementById("character-modal-backdrop");
+      if (modalBackdrop) {
+        modalBackdrop.classList.add("backdrop-blur-sm");
+      }
+    });
   }
 
   openEditCharacterModal(character, e = null) {
@@ -1519,18 +1526,24 @@ class PersonaChatApp {
       selectedStickerIndices: [],
       modalOpeningEvent: e,
     });
+
+    requestAnimationFrame(() => {
+      const modalBackdrop = document.getElementById("character-modal-backdrop");
+      if (modalBackdrop) {
+        modalBackdrop.classList.add("backdrop-blur-sm");
+      }
+    });
   }
 
   closeCharacterModal() {
     const modalBackdrop = document.getElementById("character-modal-backdrop");
     if (modalBackdrop) {
+      modalBackdrop.classList.remove("backdrop-blur-sm");
       const modalPanel = modalBackdrop.querySelector(".bg-gray-800");
       if (modalPanel) {
         modalPanel.classList.add("animate-modal-fade-out");
       }
-      // Also fade out the backdrop
-      modalBackdrop.style.transition = "opacity 0.2s ease-in-out";
-      modalBackdrop.style.opacity = "0";
+      modalBackdrop.classList.add("animate-backdrop-fade-out");
 
       setTimeout(() => {
         this.setState({

--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -38,6 +38,7 @@ import { handleGroupChatClick } from "./handlers/groupChatHandlers.js";
 import { debounce, findMessageGroup } from "./utils.js";
 
 const MODAL_FADE_OUT_DURATION_MS = 200;
+const HEADER_FADE_OUT_DURATION_MS = 300;
 
 // --- APP INITIALIZATION ---
 document.addEventListener("DOMContentLoaded", async () => {
@@ -1579,7 +1580,7 @@ class PersonaChatApp {
         header.classList.add("animate-fade-out");
         setTimeout(() => {
             this.closeCharacterEditMode();
-        }, 300);
+        }, HEADER_FADE_OUT_DURATION_MS);
     } else {
         this.closeCharacterEditMode();
     }

--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -1059,6 +1059,10 @@ class PersonaChatApp {
     setTimeout(() => this.scrollToBottom(), 0);
   }
 
+  /**
+   * @param {string | number} characterId
+   * @param {Event | null} e
+   */
   editCharacter(characterId, e = null) {
     const numericCharacterId = Number(characterId);
     const character = this.state.characters.find(
@@ -1502,6 +1506,9 @@ class PersonaChatApp {
     this.setState({ settings: { ...this.state.settings, model } });
   }
 
+  /**
+   * @param {Event | null} e
+   */
   openNewCharacterModal(e = null) {
     this.setState({
       editingCharacter: { memories: [], proactiveEnabled: true },
@@ -1519,6 +1526,10 @@ class PersonaChatApp {
     });
   }
 
+  /**
+   * @param {object} character
+   * @param {Event | null} e
+   */
   openEditCharacterModal(character, e = null) {
     this.setState({
       editingCharacter: { ...character, memories: character.memories || [] },

--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -37,6 +37,8 @@ import {
 import { handleGroupChatClick } from "./handlers/groupChatHandlers.js";
 import { debounce, findMessageGroup } from "./utils.js";
 
+const MODAL_FADE_OUT_DURATION_MS = 200;
+
 // --- APP INITIALIZATION ---
 document.addEventListener("DOMContentLoaded", async () => {
   window.personaApp = new PersonaChatApp();
@@ -1537,7 +1539,7 @@ class PersonaChatApp {
           stickerSelectionMode: false,
           selectedStickerIndices: [],
         });
-      }, 200); // Match animation duration
+      }, MODAL_FADE_OUT_DURATION_MS); // Match animation duration
     } else {
       // Fallback if modal not found
       this.setState({

--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -1551,7 +1551,7 @@ class PersonaChatApp {
     const modalBackdrop = document.getElementById("character-modal-backdrop");
     if (modalBackdrop) {
       modalBackdrop.classList.remove("backdrop-blur-sm");
-      const modalPanel = modalBackdrop.querySelector(".bg-gray-800");
+      const modalPanel = modalBackdrop.querySelector("#character-modal-panel");
       if (modalPanel) {
         modalPanel.classList.add("animate-modal-fade-out");
       }

--- a/frontend/src/language/en.ts
+++ b/frontend/src/language/en.ts
@@ -18,6 +18,7 @@ export const en: LanguageStrings = {
     deleteSticker: "Delete",
     addContact: "Add Contact",
     editContact: "Edit Contact",
+    editModeTitle: "Edit '{{name}}'",
     profileImage: "Profile Image",
     importContact: "Import Contact",
     shareContact: "Share Contact",

--- a/frontend/src/language/ko.ts
+++ b/frontend/src/language/ko.ts
@@ -18,6 +18,7 @@ export const ko: LanguageStrings = {
     deleteSticker: "삭제",
     addContact: "연락처 추가",
     editContact: "연락처 수정",
+    editModeTitle: "'{{name}}' 편집",
     profileImage: "프로필 이미지",
     importContact: "연락처 불러오기",
     shareContact: "연락처 공유하기",

--- a/frontend/src/ui.js
+++ b/frontend/src/ui.js
@@ -238,7 +238,8 @@ export async function render(app) {
         const isListAlreadyRendered = !!listContainer.querySelector("header");
         if (
           !isListAlreadyRendered ||
-          oldState.showFabMenu !== newState.showFabMenu
+          oldState.showFabMenu !== newState.showFabMenu ||
+          oldState.mobileEditModeCharacterId !== newState.mobileEditModeCharacterId
         ) {
           renderCharacterListPage(app);
         } else {
@@ -348,6 +349,39 @@ export async function render(app) {
     }
   }
 
+  // Animate character modal opening
+  if (newState.showCharacterModal && newState.modalOpeningEvent) {
+    const event = newState.modalOpeningEvent;
+    // Use requestAnimationFrame to ensure the element is in the DOM before animating
+    requestAnimationFrame(() => {
+        const modalBackdrop = document.getElementById("character-modal-backdrop");
+        const modalPanel = modalBackdrop?.querySelector(".bg-gray-800");
+
+        if (modalPanel) {
+            const rect = modalPanel.getBoundingClientRect();
+            const initialScale = 0.2;
+            const modalCenterX = rect.left + rect.width / 2;
+            const modalCenterY = rect.top + rect.height / 2;
+            const initialX = event.clientX - modalCenterX;
+            const initialY = event.clientY - modalCenterY;
+
+            modalPanel.style.opacity = 0; // prevent flash
+
+            modalPanel.animate([
+                { transform: `translate(${initialX}px, ${initialY}px) scale(${initialScale})`, opacity: 0 },
+                { transform: 'translate(0, 0) scale(1)', opacity: 1 }
+            ], {
+                duration: 350,
+                easing: 'cubic-bezier(0.215, 0.610, 0.355, 1)',
+                fill: 'forwards'
+            });
+        }
+    });
+
+    // Clean up the event so it doesn't fire again
+    app.setState({ modalOpeningEvent: null });
+  }
+
   lucide.createIcons();
   setupConditionalBlur();
 }
@@ -356,6 +390,7 @@ export async function render(app) {
 
 function shouldUpdateCharacterList(oldState, newState) {
   return (
+    oldState.mobileEditModeCharacterId !== newState.mobileEditModeCharacterId ||
     oldState.selectedChatId !== newState.selectedChatId ||
     oldState.showFabMenu !== newState.showFabMenu ||
     oldState.showMobileSearch !== newState.showMobileSearch ||

--- a/frontend/src/ui.js
+++ b/frontend/src/ui.js
@@ -358,7 +358,7 @@ export async function render(app) {
     // Use requestAnimationFrame to ensure the element is in the DOM before animating
     requestAnimationFrame(() => {
         const modalBackdrop = document.getElementById("character-modal-backdrop");
-        const modalPanel = modalBackdrop?.querySelector(".bg-gray-800");
+        const modalPanel = modalBackdrop?.querySelector("#character-modal-panel");
 
         if (modalPanel) {
             const rect = modalPanel.getBoundingClientRect();

--- a/frontend/src/ui.js
+++ b/frontend/src/ui.js
@@ -392,62 +392,65 @@ export async function render(app) {
 // --- RENDER HELPER FUNCTIONS ---
 
 function shouldUpdateCharacterList(oldState, newState) {
-  return (
-    oldState.mobileEditModeCharacterId !== newState.mobileEditModeCharacterId ||
-    oldState.selectedChatId !== newState.selectedChatId ||
-    oldState.showFabMenu !== newState.showFabMenu ||
-    oldState.showMobileSearch !== newState.showMobileSearch ||
-    oldState.searchQuery !== newState.searchQuery ||
+  const conditions = [
+    oldState.mobileEditModeCharacterId !== newState.mobileEditModeCharacterId,
+    oldState.selectedChatId !== newState.selectedChatId,
+    oldState.showFabMenu !== newState.showFabMenu,
+    oldState.showMobileSearch !== newState.showMobileSearch,
+    oldState.searchQuery !== newState.searchQuery,
     JSON.stringify(oldState.characters) !==
-      JSON.stringify(newState.characters) ||
+      JSON.stringify(newState.characters),
     JSON.stringify(oldState.unreadCounts) !==
-      JSON.stringify(newState.unreadCounts) ||
-    JSON.stringify(oldState.messages) !== JSON.stringify(newState.messages)
-  );
+      JSON.stringify(newState.unreadCounts),
+    JSON.stringify(oldState.messages) !== JSON.stringify(newState.messages),
+  ];
+  return conditions.some(condition => condition);
 }
 
 function shouldUpdateSidebar(oldState, newState) {
   // This function checks if any state related to the sidebar has changed
-  return (
-    oldState.sidebarCollapsed !== newState.sidebarCollapsed ||
-    oldState.searchQuery !== newState.searchQuery ||
+  const conditions = [
+    oldState.sidebarCollapsed !== newState.sidebarCollapsed,
+    oldState.searchQuery !== newState.searchQuery,
     JSON.stringify(Array.from(oldState.expandedCharacterIds || [])) !==
-      JSON.stringify(Array.from(newState.expandedCharacterIds || [])) ||
-    oldState.editingChatRoomId !== newState.editingChatRoomId ||
+      JSON.stringify(Array.from(newState.expandedCharacterIds || [])),
+    oldState.editingChatRoomId !== newState.editingChatRoomId,
     JSON.stringify(oldState.characters) !==
-      JSON.stringify(newState.characters) ||
-    oldState.selectedChatId !== newState.selectedChatId ||
+      JSON.stringify(newState.characters),
+    oldState.selectedChatId !== newState.selectedChatId,
     JSON.stringify(oldState.unreadCounts) !==
-      JSON.stringify(newState.unreadCounts) ||
-    JSON.stringify(oldState.messages) !== JSON.stringify(newState.messages) ||
-    JSON.stringify(oldState.chatRooms) !== JSON.stringify(newState.chatRooms) ||
+      JSON.stringify(newState.unreadCounts),
+    JSON.stringify(oldState.messages) !== JSON.stringify(newState.messages),
+    JSON.stringify(oldState.chatRooms) !== JSON.stringify(newState.chatRooms),
     JSON.stringify(oldState.groupChats) !==
-      JSON.stringify(newState.groupChats) ||
-    JSON.stringify(oldState.openChats) !== JSON.stringify(newState.openChats)
-  );
+      JSON.stringify(newState.groupChats),
+    JSON.stringify(oldState.openChats) !== JSON.stringify(newState.openChats),
+  ];
+  return conditions.some(condition => condition);
 }
 
 function shouldUpdateMainChat(oldState, newState) {
   // This function checks if any state related to the main chat has changed
-  return (
-    oldState.selectedChatId !== newState.selectedChatId ||
-    oldState.editingMessageId !== newState.editingMessageId ||
-    JSON.stringify(oldState.messages) !== JSON.stringify(newState.messages) ||
-    oldState.typingCharacterId !== newState.typingCharacterId ||
-    oldState.isWaitingForResponse !== newState.isWaitingForResponse ||
-    oldState.imageToSend !== newState.imageToSend ||
-    oldState.showUserStickerPanel !== newState.showUserStickerPanel ||
-    oldState.showInputOptions !== newState.showInputOptions ||
-    oldState.stickerToSend !== newState.stickerToSend ||
+  const conditions = [
+    oldState.selectedChatId !== newState.selectedChatId,
+    oldState.editingMessageId !== newState.editingMessageId,
+    JSON.stringify(oldState.messages) !== JSON.stringify(newState.messages),
+    oldState.typingCharacterId !== newState.typingCharacterId,
+    oldState.isWaitingForResponse !== newState.isWaitingForResponse,
+    oldState.imageToSend !== newState.imageToSend,
+    oldState.showUserStickerPanel !== newState.showUserStickerPanel,
+    oldState.showInputOptions !== newState.showInputOptions,
+    oldState.stickerToSend !== newState.stickerToSend,
     JSON.stringify(oldState.userStickers) !==
-      JSON.stringify(newState.userStickers) ||
+      JSON.stringify(newState.userStickers),
     JSON.stringify([...oldState.expandedStickers]) !==
-      JSON.stringify([...newState.expandedStickers]) ||
+      JSON.stringify([...newState.expandedStickers]),
     // Group/open chat related state changes
     JSON.stringify(oldState.groupChats) !==
-      JSON.stringify(newState.groupChats) ||
-    JSON.stringify(oldState.openChats) !== JSON.stringify(newState.openChats)
-  );
+      JSON.stringify(newState.groupChats),
+    JSON.stringify(oldState.openChats) !== JSON.stringify(newState.openChats),
+  ];
+  return conditions.some(condition => condition);
 }
 
 function shouldUpdateModals(oldState, newState) {
@@ -456,53 +459,53 @@ function shouldUpdateModals(oldState, newState) {
   // If the settings modal is open, we don't re-render it just for settings changes.
   // This prevents the modal from resetting while the user is typing in input fields.
   if (newState.showSettingsModal && oldState.showSettingsModal) {
-    // We need to check for specific state changes that require a re-render
-    // even when the settings modal is open.
-    return (
-      JSON.stringify(oldState.settingsSnapshots) !==
-        JSON.stringify(newState.settingsSnapshots) ||
-      oldState.settings.model !== newState.settings.model ||
-      oldState.showPromptModal !== newState.showPromptModal ||
-      JSON.stringify(oldState.openSettingsSections) !==
-        JSON.stringify(newState.openSettingsSections) ||
-      oldState.enableDebugLogs !== newState.enableDebugLogs ||
-      JSON.stringify(oldState.debugLogs) !==
-        JSON.stringify(newState.debugLogs) ||
-      // Detect active panel change in desktop settings UI
-      oldState.ui?.desktopSettings?.activePanel !==
-        newState.ui?.desktopSettings?.activePanel ||
-      // Detect settings UI mode change
-      oldState.ui?.settingsUIMode !== newState.ui?.settingsUIMode
-    );
+    const conditions = [
+        JSON.stringify(oldState.settingsSnapshots) !==
+          JSON.stringify(newState.settingsSnapshots),
+        oldState.settings.model !== newState.settings.model,
+        oldState.showPromptModal !== newState.showPromptModal,
+        JSON.stringify(oldState.openSettingsSections) !==
+          JSON.stringify(newState.openSettingsSections),
+        oldState.enableDebugLogs !== newState.enableDebugLogs,
+        JSON.stringify(oldState.debugLogs) !==
+          JSON.stringify(newState.debugLogs),
+        // Detect active panel change in desktop settings UI
+        oldState.ui?.desktopSettings?.activePanel !==
+          newState.ui?.desktopSettings?.activePanel,
+        // Detect settings UI mode change
+        oldState.ui?.settingsUIMode !== newState.ui?.settingsUIMode
+    ];
+    return conditions.some(condition => condition);
   }
 
-  return (
-    JSON.stringify(oldState.modal) !== JSON.stringify(newState.modal) ||
-    oldState.showSettingsModal !== newState.showSettingsModal ||
-    oldState.showCharacterModal !== newState.showCharacterModal ||
-    oldState.showMobileSearch !== newState.showMobileSearch ||
-    oldState.showPromptModal !== newState.showPromptModal ||
-    oldState.showCreateGroupChatModal !== newState.showCreateGroupChatModal ||
-    oldState.showCreateOpenChatModal !== newState.showCreateOpenChatModal ||
-    oldState.showEditGroupChatModal !== newState.showEditGroupChatModal ||
-    oldState.showDebugLogsModal !== newState.showDebugLogsModal ||
+  const conditions = [
+    JSON.stringify(oldState.modal) !== JSON.stringify(newState.modal),
+    oldState.showSettingsModal !== newState.showSettingsModal,
+    oldState.showCharacterModal !== newState.showCharacterModal,
+    oldState.showMobileSearch !== newState.showMobileSearch,
+    oldState.showPromptModal !== newState.showPromptModal,
+    oldState.showCreateGroupChatModal !== newState.showCreateGroupChatModal,
+    oldState.showCreateOpenChatModal !== newState.showCreateOpenChatModal,
+    oldState.showEditGroupChatModal !== newState.showEditGroupChatModal,
+    oldState.showDebugLogsModal !== newState.showDebugLogsModal,
     (newState.showCharacterModal &&
       JSON.stringify(oldState.editingCharacter) !==
-        JSON.stringify(newState.editingCharacter)) ||
+        JSON.stringify(newState.editingCharacter)),
     (newState.showPromptModal &&
       JSON.stringify(oldState.settings.prompts) !==
-        JSON.stringify(newState.settings.prompts)) ||
+        JSON.stringify(newState.settings.prompts)),
     (newState.showCreateGroupChatModal &&
       JSON.stringify(oldState.characters) !==
-        JSON.stringify(newState.characters)) ||
+        JSON.stringify(newState.characters)),
     (newState.showEditGroupChatModal &&
       JSON.stringify(oldState.editingGroupChat) !==
-        JSON.stringify(newState.editingGroupChat)) ||
+        JSON.stringify(newState.editingGroupChat)),
     (newState.showDebugLogsModal &&
       JSON.stringify(oldState.debugLogs) !==
-        JSON.stringify(newState.debugLogs)) ||
+        JSON.stringify(newState.debugLogs)),
     (newState.showMobileSearch && oldState.searchQuery !== newState.searchQuery)
-  );
+  ];
+  return conditions.some(condition => condition);
 }
 
 function shouldUpdateConfirmationModal(oldState, newState) {

--- a/frontend/src/ui.js
+++ b/frontend/src/ui.js
@@ -34,6 +34,9 @@ import {
 } from "./components/CharacterListPage.js";
 import { renderSearchModal } from "./components/SearchModal.js";
 
+const MODAL_ANIMATION_INITIAL_SCALE = 0.2;
+const MODAL_ANIMATION_DURATION_MS = 350;
+
 export function adjustMessageContainerPadding() {
   const messagesContainer = document.getElementById("messages-container");
   const inputAreaWrapper = document.getElementById("input-area-wrapper");
@@ -359,7 +362,7 @@ export async function render(app) {
 
         if (modalPanel) {
             const rect = modalPanel.getBoundingClientRect();
-            const initialScale = 0.2;
+            const initialScale = MODAL_ANIMATION_INITIAL_SCALE;
             const modalCenterX = rect.left + rect.width / 2;
             const modalCenterY = rect.top + rect.height / 2;
             const initialX = event.clientX - modalCenterX;
@@ -371,7 +374,7 @@ export async function render(app) {
                 { transform: `translate(${initialX}px, ${initialY}px) scale(${initialScale})`, opacity: 0 },
                 { transform: 'translate(0, 0) scale(1)', opacity: 1 }
             ], {
-                duration: 350,
+                duration: MODAL_ANIMATION_DURATION_MS,
                 easing: 'cubic-bezier(0.215, 0.610, 0.355, 1)',
                 fill: 'forwards'
             });

--- a/frontend/static/css/animations.css
+++ b/frontend/static/css/animations.css
@@ -1,0 +1,149 @@
+/* 커스텀 애니메이션 */
+@keyframes slideUp {
+  0% {
+    opacity: 0;
+    transform: translateY(15px);
+    scale: 0.95;
+  }
+
+  100% {
+    opacity: 1;
+    transform: translateY(0);
+    scale: 1;
+  }
+}
+
+.animate-slideUp {
+  animation: slideUp 0.6s cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+@keyframes fadeIn {
+  from {
+    opacity: 0;
+  }
+
+  to {
+    opacity: 1;
+  }
+}
+
+.animate-fadeIn {
+  animation: fadeIn 0.3s ease-in-out;
+}
+
+@keyframes fab-menu-in {
+  from {
+    transform: scale(0.95) translateY(10px);
+    opacity: 0;
+  }
+  to {
+    transform: scale(1) translateY(0);
+    opacity: 1;
+  }
+}
+
+.animate-fab-menu-in {
+  animation: fab-menu-in 0.2s ease-out forwards;
+}
+
+@keyframes slide-down {
+  from {
+    transform: translateY(-100%);
+  }
+  to {
+    transform: translateY(0);
+  }
+}
+
+.animate-slide-down {
+  animation: slide-down 0.3s ease-out forwards;
+}
+
+@keyframes slide-down-fast {
+  from {
+    transform: translateY(-20px);
+    opacity: 0;
+  }
+  to {
+    transform: translateY(0);
+    opacity: 1;
+  }
+}
+
+.animate-slide-down-fast {
+    animation: slide-down-fast 0.3s ease-out forwards;
+}
+
+.height-transition {
+    transition: max-height 0.7s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+/* 로딩 스피너 */
+@keyframes pulse {
+  50% {
+    opacity: 0.5;
+  }
+}
+
+.animate-pulse {
+  animation: pulse 2s cubic-bezier(0.4, 0, 0.6, 1) infinite;
+}
+
+/* Added for mobile edit mode header */
+@keyframes fadeInHeader {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
+@keyframes fadeOutHeader {
+  from { opacity: 1; }
+  to { opacity: 0; }
+}
+
+.animate-fade-in {
+  animation: fadeInHeader 0.3s ease-out forwards;
+}
+
+.animate-fade-out {
+  animation: fadeOutHeader 0.3s ease-out forwards;
+}
+
+/* Added for long-press ripple effect */
+.ripple {
+  position: absolute;
+  border-radius: 50%;
+  background-color: rgba(255, 255, 255, 0.3);
+  transform: scale(0);
+  animation: ripple 0.6s ease-out;
+  pointer-events: none;
+  width: 100px; /* Set a fixed size */
+  height: 100px; /* Set a fixed size */
+  margin-top: -50px; /* Adjust for size */
+  margin-left: -50px; /* Adjust for size */
+}
+
+@keyframes ripple {
+  to {
+    transform: scale(4);
+    opacity: 0;
+  }
+}
+
+/* Added for modal close animation */
+@keyframes modalFadeOut {
+  from { opacity: 1; transform: scale(1); }
+  to { opacity: 0; transform: scale(0.95); }
+}
+
+.animate-modal-fade-out {
+  animation: modalFadeOut 0.2s ease-in-out forwards;
+}
+
+@keyframes backdropFadeOut {
+  from { opacity: 1; }
+  to { opacity: 0; }
+}
+
+.animate-backdrop-fade-out {
+  animation: backdropFadeOut 0.2s ease-in-out forwards;
+}

--- a/frontend/static/css/main.css
+++ b/frontend/static/css/main.css
@@ -3,86 +3,6 @@ html {
   font-size: calc(var(--font-scale, 1) * 14px);
 }
 
-/* 커스텀 애니메이션 */
-@keyframes slideUp {
-  0% {
-    opacity: 0;
-    transform: translateY(15px);
-    scale: 0.95;
-  }
-
-  100% {
-    opacity: 1;
-    transform: translateY(0);
-    scale: 1;
-  }
-}
-
-.animate-slideUp {
-  animation: slideUp 0.6s cubic-bezier(0.16, 1, 0.3, 1);
-}
-
-@keyframes fadeIn {
-  from {
-    opacity: 0;
-  }
-
-  to {
-    opacity: 1;
-  }
-}
-
-.animate-fadeIn {
-  animation: fadeIn 0.3s ease-in-out;
-}
-
-@keyframes fab-menu-in {
-  from {
-    transform: scale(0.95) translateY(10px);
-    opacity: 0;
-  }
-  to {
-    transform: scale(1) translateY(0);
-    opacity: 1;
-  }
-}
-
-.animate-fab-menu-in {
-  animation: fab-menu-in 0.2s ease-out forwards;
-}
-
-@keyframes slide-down {
-  from {
-    transform: translateY(-100%);
-  }
-  to {
-    transform: translateY(0);
-  }
-}
-
-.animate-slide-down {
-  animation: slide-down 0.3s ease-out forwards;
-}
-
-@keyframes slide-down-fast {
-  from {
-    transform: translateY(-20px);
-    opacity: 0;
-  }
-  to {
-    transform: translateY(0);
-    opacity: 1;
-  }
-}
-
-.animate-slide-down-fast {
-    animation: slide-down-fast 0.3s ease-out forwards;
-}
-
-.height-transition {
-    transition: max-height 0.7s cubic-bezier(0.4, 0, 0.2, 1);
-}
-
 .line-clamp-2 {
   display: -webkit-box;
   -webkit-line-clamp: 2;
@@ -99,17 +19,6 @@ textarea,
 textarea::-webkit-scrollbar,
 .overflow-y-auto::-webkit-scrollbar {
   display: none;
-}
-
-/* 로딩 스피너 */
-@keyframes pulse {
-  50% {
-    opacity: 0.5;
-  }
-}
-
-.animate-pulse {
-  animation: pulse 2s cubic-bezier(0.4, 0, 0.6, 1) infinite;
 }
 
 /* 단어 단위 줄바꿈 */
@@ -471,66 +380,8 @@ button > svg {
   background-color: rgba(35, 42, 55, 0.7);
 }
 
-/* Added for mobile edit mode header */
-@keyframes fadeInHeader {
-  from { opacity: 0; }
-  to { opacity: 1; }
-}
-
-@keyframes fadeOutHeader {
-  from { opacity: 1; }
-  to { opacity: 0; }
-}
-
-.animate-fade-in {
-  animation: fadeInHeader 0.3s ease-out forwards;
-}
-
-.animate-fade-out {
-  animation: fadeOutHeader 0.3s ease-out forwards;
-}
-
 /* Added for long-press ripple effect */
 .character-list-item {
   position: relative;
   overflow: hidden;
-}
-
-.ripple {
-  position: absolute;
-  border-radius: 50%;
-  background-color: rgba(255, 255, 255, 0.3);
-  transform: scale(0);
-  animation: ripple 0.6s ease-out;
-  pointer-events: none;
-  width: 100px; /* Set a fixed size */
-  height: 100px; /* Set a fixed size */
-  margin-top: -50px; /* Adjust for size */
-  margin-left: -50px; /* Adjust for size */
-}
-
-@keyframes ripple {
-  to {
-    transform: scale(4);
-    opacity: 0;
-  }
-}
-
-/* Added for modal close animation */
-@keyframes modalFadeOut {
-  from { opacity: 1; transform: scale(1); }
-  to { opacity: 0; transform: scale(0.95); }
-}
-
-.animate-modal-fade-out {
-  animation: modalFadeOut 0.2s ease-in-out forwards;
-}
-
-@keyframes backdropFadeOut {
-  from { opacity: 1; }
-  to { opacity: 0; }
-}
-
-.animate-backdrop-fade-out {
-  animation: backdropFadeOut 0.2s ease-in-out forwards;
 }

--- a/frontend/static/index.css
+++ b/frontend/static/index.css
@@ -128,6 +128,8 @@ textarea::-webkit-scrollbar,
   bottom: 0;
   background-color: rgba(0, 0, 0, 0.7);
   z-index: 40;
+  backdrop-filter: blur(4px);
+  transition: backdrop-filter 0.3s ease-out;
 }
 
 /* 모달 컨테이너 */
@@ -499,7 +501,7 @@ button > svg {
   border-radius: 50%;
   background-color: rgba(255, 255, 255, 0.3);
   transform: scale(0);
-  animation: ripple 0.6s linear;
+  animation: ripple 0.6s ease-out;
   pointer-events: none;
   width: 100px; /* Set a fixed size */
   height: 100px; /* Set a fixed size */
@@ -522,4 +524,13 @@ button > svg {
 
 .animate-modal-fade-out {
   animation: modalFadeOut 0.2s ease-in-out forwards;
+}
+
+@keyframes backdropFadeOut {
+  from { opacity: 1; }
+  to { opacity: 0; }
+}
+
+.animate-backdrop-fade-out {
+  animation: backdropFadeOut 0.2s ease-in-out forwards;
 }

--- a/frontend/static/index.css
+++ b/frontend/static/index.css
@@ -468,3 +468,58 @@ button > svg {
 .message-bubble-them {
   background-color: rgba(35, 42, 55, 0.7);
 }
+
+/* Added for mobile edit mode header */
+@keyframes fadeInHeader {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
+@keyframes fadeOutHeader {
+  from { opacity: 1; }
+  to { opacity: 0; }
+}
+
+.animate-fade-in {
+  animation: fadeInHeader 0.3s ease-out forwards;
+}
+
+.animate-fade-out {
+  animation: fadeOutHeader 0.3s ease-out forwards;
+}
+
+/* Added for long-press ripple effect */
+.character-list-item {
+  position: relative;
+  overflow: hidden;
+}
+
+.ripple {
+  position: absolute;
+  border-radius: 50%;
+  background-color: rgba(255, 255, 255, 0.3);
+  transform: scale(0);
+  animation: ripple 0.6s linear;
+  pointer-events: none;
+  width: 100px; /* Set a fixed size */
+  height: 100px; /* Set a fixed size */
+  margin-top: -50px; /* Adjust for size */
+  margin-left: -50px; /* Adjust for size */
+}
+
+@keyframes ripple {
+  to {
+    transform: scale(4);
+    opacity: 0;
+  }
+}
+
+/* Added for modal close animation */
+@keyframes modalFadeOut {
+  from { opacity: 1; transform: scale(1); }
+  to { opacity: 0; transform: scale(0.95); }
+}
+
+.animate-modal-fade-out {
+  animation: modalFadeOut 0.2s ease-in-out forwards;
+}


### PR DESCRIPTION
## Description

Adds an edit mode to the mobile character list, activated by long-pressing a character item.
The top bar transitions to an edit context menu with options to cancel or initiate editing.

This commit also includes significant refinements and bug fixes for a robust and polished user experience:
- Implements various UI animations for smoother interactions:
  - Ripple effect on long-press.
  - Fade-in/out transitions for the edit header.
  - Pop-from-source animation for the character modal opening.
  - Gentle fade-out for the character modal closing.
- Resolves event handler conflicts and rendering issues that caused functionality regressions (e.g., search, FAB menu).
- Refactors long-press detection to use event delegation for consistent behavior across navigation.

## Checklist

- [x] I have tested my changes locally.
- [ ] I have updated the documentation...
- [ ] and docstrings(JSDoc or KDoc).
- [x] I've also checked the code for any linting error/warnings.
- [ ] I formatted the code with the formatter.

## Additional Notes

This PR addresses the implementation of the mobile character editing feature, including several rounds of bug fixes and UI/UX refinements based on user feedback.