### PR TITLE
fix: Add missing language literals and update translations

### DIFF
--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -6104,8 +6104,8 @@ class PersonaChatApp {
 
     if (!characterName) {
       this.showInfoModal(
-        t("character_name_required_title"),
-        t("character_name_required_message"),
+        t("characterNameRequiredTitle"),
+        t("characterNameRequiredMessage"),
       );
       return;
     }

--- a/frontend/src/language/en.ts
+++ b/frontend/src/language/en.ts
@@ -501,8 +501,8 @@ export const en: LanguageStrings = {
     characterCardSaveError: {
       message: "Failed to save character card.",
     },
-    character_name_required_title: "Name required",
-    character_name_required_message: "Please enter a character name first.",
+    characterNameRequiredTitle: "Name required",
+    characterNameRequiredMessage: "Please enter a character name first.",
     aiGenerationComplete: {
       title: "AI Generation Complete",
       message:

--- a/frontend/src/language/en.ts
+++ b/frontend/src/language/en.ts
@@ -246,8 +246,6 @@ export const en: LanguageStrings = {
     performanceComingSoon:
       "Performance optimization options will be supported in future updates.",
     experimentalFeatures: "Experimental Features",
-    useNewInputBar: "New Input Bar Design",
-    useNewInputBarDesc: "Uses a rounded, floating input bar design.",
     experimentalWarning:
       "Experimental features may be unstable and cause unexpected behavior.",
     warningNote: "Warning",

--- a/frontend/src/language/ko.ts
+++ b/frontend/src/language/ko.ts
@@ -140,13 +140,17 @@ export const ko: LanguageStrings = {
     randomFirstMessagePromptDescription:
       "이 프롬프트는 새로운 첫 메시지를 생성할 때 사용됩니다.",
     snsForcePrompt: "SNS 강제 생성 프롬프트",
-    snsForcePromptDescription: "이 프롬프트는 SNS 포스트를 강제로 생성할 때 사용됩니다. 최근 대화 내용을 기반으로 캐릭터의 SNS 포스트를 생성합니다.",
+    snsForcePromptDescription:
+      "이 프롬프트는 SNS 포스트를 강제로 생성할 때 사용됩니다. 최근 대화 내용을 기반으로 캐릭터의 SNS 포스트를 생성합니다.",
     naiStickerPrompt: "NAI 스티커 생성 프롬프트",
-    naiStickerPromptDescription: "이 프롬프트는 NovelAI를 통해 스티커를 생성할 때 사용됩니다. 대화 상황에 맞는 감정과 상황을 분석하여 스티커 생성 요청을 만듭니다.",
+    naiStickerPromptDescription:
+      "이 프롬프트는 NovelAI를 통해 스티커를 생성할 때 사용됩니다. 대화 상황에 맞는 감정과 상황을 분석하여 스티커 생성 요청을 만듭니다.",
     groupChatPrompt: "단톡방 프롬프트",
-    groupChatPromptDescription: "이 프롬프트는 단톡방에서 AI 캐릭터들이 대화할 때 사용됩니다. ChatML 형식으로 작성되어야 합니다.",
-    openChatPrompt: "오픈톡방 프롬프트", 
-    openChatPromptDescription: "이 프롬프트는 오픈톡방에서 AI 캐릭터들이 대화할 때 사용됩니다. ChatML 형식으로 작성되어야 합니다.",
+    groupChatPromptDescription:
+      "이 프롬프트는 단톡방에서 AI 캐릭터들이 대화할 때 사용됩니다. ChatML 형식으로 작성되어야 합니다.",
+    openChatPrompt: "오픈톡방 프롬프트",
+    openChatPromptDescription:
+      "이 프롬프트는 오픈톡방에서 AI 캐릭터들이 대화할 때 사용됩니다. ChatML 형식으로 작성되어야 합니다.",
     resetAllPrompts: "프롬프트 초기화!",
     resetAllPromptsConfirmation:
       "모든 프롬프트를 초기화하시겠습니까? 이 작업은 되돌릴 수 없습니다.",
@@ -245,8 +249,6 @@ export const ko: LanguageStrings = {
     performanceComingSoon:
       "성능 최적화 옵션은 향후 업데이트에서 지원될 예정입니다.",
     experimentalFeatures: "실험적 기능",
-    useNewInputBar: "새로운 입력창 디자인",
-    useNewInputBarDesc: "둥글고 떠다니는 디자인의 입력창을 사용합니다.",
     experimentalWarning:
       "실험적 기능은 불안정할 수 있으며, 예상치 못한 동작을 할 수 있습니다.",
     warningNote: "주의사항",
@@ -755,7 +757,8 @@ export const ko: LanguageStrings = {
     naturalValue: "자연스러운 값: {{level}}%",
     hypnosisValue: "최면 값: {{level}}%",
     settingsWarning: "최면 제어는 캐릭터의 자연스러운 감정을 무시합니다",
-    dangerousFeature: "⚠️ 이 기능은 스토리의 자연스러운 진행을 방해할 수 있습니다"
+    dangerousFeature:
+      "⚠️ 이 기능은 스토리의 자연스러운 진행을 방해할 수 있습니다",
   },
   sns: {
     characterListTitle: "캐릭터 목록",
@@ -811,19 +814,19 @@ export const ko: LanguageStrings = {
       affectionLevel: "호감도: {{level}}%",
       intimacyLevel: "친밀도: {{level}}%",
       trustLevel: "신뢰도: {{level}}%",
-      romanceLevel: "연애감정: {{level}}%"
+      romanceLevel: "연애감정: {{level}}%",
     },
     accessDeniedDescription: "이 콘텐츠를 보려면 더 높은 호감도가 필요합니다.",
     requiresAffection: "호감도 {{level}}% 이상 필요",
-    requiresIntimacy: "친밀도 {{level}}% 이상 필요", 
+    requiresIntimacy: "친밀도 {{level}}% 이상 필요",
     requiresTrust: "신뢰도 {{level}}% 이상 필요",
     requiresRomance: "연애감정 {{level}}% 이상 필요",
     backToMain: "메인 계정으로 돌아가기",
     affection: "호감도",
-    intimacy: "친밀도", 
+    intimacy: "친밀도",
     trust: "신뢰도",
     romanticInterest: "연애감정",
     openSNSList: "SNS 목록 보기",
-    viewSNS: "{{name}}의 SNS 보기"
+    viewSNS: "{{name}}의 SNS 보기",
   },
 };

--- a/frontend/src/language/ko.ts
+++ b/frontend/src/language/ko.ts
@@ -502,8 +502,8 @@ export const ko: LanguageStrings = {
     characterCardSaveError: {
       message: "캐릭터 카드 저장에 실패했습니다.",
     },
-    character_name_required_title: "이름 필요",
-    character_name_required_message: "캐릭터 이름을 먼저 입력해주세요.",
+    characterNameRequiredTitle: "이름 필요",
+    characterNameRequiredMessage: "캐릭터 이름을 먼저 입력해주세요.",
     aiGenerationComplete: {
       title: "AI 생성 완료",
       message: '캐릭터 "{{characterName}}"의 정보 생성이 완료되었습니다.',

--- a/frontend/src/language/language.d.ts
+++ b/frontend/src/language/language.d.ts
@@ -465,8 +465,8 @@ export type LanguageStrings = {
     characterCardSaveError: {
       message: string;
     };
-    character_name_required_title: string;
-    character_name_required_message: string;
+    characterNameRequiredTitle: string;
+    characterNameRequiredMessage: string;
     aiGenerationComplete: {
       title: string;
       message: string;

--- a/frontend/src/language/language.d.ts
+++ b/frontend/src/language/language.d.ts
@@ -18,6 +18,7 @@ export type LanguageStrings = {
     deleteSticker: string;
     addContact: string;
     editContact: string;
+    editModeTitle: string;
     profileImage: string;
     importContact: string;
     shareContact: string;
@@ -75,6 +76,8 @@ export type LanguageStrings = {
     resetDataFinalConfirm: string;
     resetDataComplete: string;
     resetDataFailed: string;
+    restoreSnapshotConfirm: string;
+    deleteSnapshotConfirm: string;
   };
   mainChat: {
     uploadPhoto: string;
@@ -125,6 +128,14 @@ export type LanguageStrings = {
     characterSheetGenerationPromptDescription: string;
     mainChatPromptDescription: string;
     randomFirstMessagePromptDescription: string;
+    snsForcePrompt: string;
+    snsForcePromptDescription: string;
+    naiStickerPrompt: string;
+    naiStickerPromptDescription: string;
+    groupChatPrompt: string;
+    groupChatPromptDescription: string;
+    openChatPrompt: string;
+    openChatPromptDescription: string;
     resetAllPrompts: string;
     resetAllPromptsConfirmation: string;
     restoreFailed: string;
@@ -135,6 +146,7 @@ export type LanguageStrings = {
     noSnapshots: string;
     title: string;
     aiSettings: string;
+    scaleSettings: string;
     advancedSettings: string;
     apiKey: string;
     apiKeyPlaceholder: string;
@@ -262,6 +274,8 @@ export type LanguageStrings = {
       stickerData: string;
       debugLogs: string;
     };
+    uiSizePreviewMessage1: string;
+    uiSizePreviewMessage2: string;
   };
   sidebar: {
     startNewChat: string;
@@ -444,6 +458,23 @@ export type LanguageStrings = {
     resetPromptMessage: string;
     resetPromptCompleteTitle: string;
     resetPromptCompleteMessage: string;
+    selectChat: {
+      message: string;
+      newChat: string;
+    };
+    characterCardSaveError: {
+      message: string;
+    };
+    character_name_required_title: string;
+    character_name_required_message: string;
+    aiGenerationComplete: {
+      title: string;
+      message: string;
+    };
+    generationFailed: {
+      title: string;
+      message: string;
+    };
   };
   ui: {
     discardChanges: string;
@@ -461,8 +492,12 @@ export type LanguageStrings = {
     fileProcessingError: string;
     fileProcessingAlert: string;
     fileSizeExceeded: string;
+    fileSizeExceededMessage: string;
     unsupportedFormat: string;
+    unsupportedFormatMessage: string;
     stickerProcessingError: string;
+    stickerProcessingErrorConsole: string;
+    stickerProcessingErrorMessage: string;
     storageFull: string;
     storageFullMessage: string;
     groupChatNamePlaceholder: string;
@@ -593,6 +628,7 @@ export type LanguageStrings = {
     storageFullMessage: string;
     selectModeDeselect: string;
     selectModeSelect: string;
+    selectAll: string;
   };
   landing: {
     welcomeTitle: string;
@@ -640,6 +676,31 @@ export type LanguageStrings = {
     saveApiConfigsFailed: string;
     noMasterPasswordForDecryption: string;
     loadApiConfigsFailed: string;
+  };
+  search: {
+    prompt: string;
+    noResults: string;
+  };
+  generatingStatus: {
+    generating: string;
+  };
+  hypnosis: {
+    hypnosisControl: string;
+    enabled: string;
+    disabled: string;
+    affectionControl: string;
+    intimacyControl: string;
+    trustControl: string;
+    romanceControl: string;
+    forceLoveUnlock: string;
+    snsFullAccess: string;
+    secretAccountAccess: string;
+    currentLevel: string;
+    override: string;
+    naturalValue: string;
+    hypnosisValue: string;
+    settingsWarning: string;
+    dangerousFeature: string;
   };
   sns: {
     characterListTitle: string;


### PR DESCRIPTION
## Description
This pull request addresses missing language literals in `frontend/src/language/language.d.ts` and updates corresponding translation files (`en.ts`, `ko.ts`).

The following changes were made:
- Added new type definitions for various UI elements and features in `language.d.ts`, including:
    - `editModeTitle`
    - `restoreSnapshotConfirm`, `deleteSnapshotConfirm`
    - Prompt-related strings (`snsForcePrompt`, `naiStickerPrompt`, `groupChatPrompt`, `openChatPrompt` and their descriptions)
    - `scaleSettings`
    - UI size preview messages (`uiSizePreviewMessage1`, `uiSizePreviewMessage2`)
    - Chat selection and character card save errors
    - AI generation status and failure messages
    - File processing and sticker processing error messages
    - `selectAll`
    - Search-related strings (`prompt`, `noResults`)
    - Hypnosis control related strings
    - SNS related strings
- Removed `useNewInputBar` and `useNewInputBarDesc` from `en.ts` and `ko.ts`.
- Applied minor formatting adjustments in `ko.ts`.

These updates ensure proper type definition, complete internationalization, and maintain consistency across the application.

## Checklist

- [x] I have tested my changes locally.
- [ ] I have updated the documentation...
- [ ] and docstrings(JSDoc or KDoc).
- [x] I've also checked the code for any linting error/warnings.
- [ ] I formatted the code with the formatter.

Closes #46