### PR TITLE
fix(frontend): Resolve tooltip positioning in prompt modal

### DIFF
--- a/frontend/src/components/PromptModal.js
+++ b/frontend/src/components/PromptModal.js
@@ -61,8 +61,8 @@ export async function renderPromptModal(app) {
                         <div class="flex items-center gap-2">
                             <h4 class="text-base font-semibold text-blue-300">${title}</h4>
                             <div class="relative group">
-                                <i data-lucide="help-circle" class="w-4 h-4 text-gray-400 cursor-pointer"></i>
-                                <div class="absolute bottom-full mb-2 w-96 bg-gray-900 text-white text-xs rounded-lg p-4 opacity-0 group-hover:opacity-100 transition-opacity duration-300 pointer-events-none">
+                                <i data-lucide="help-circle" class="w-4 h-4 text-gray-400 cursor-pointer help-icon"></i>
+                                <div class="hidden w-96 bg-gray-900 text-white text-xs rounded-lg p-4" data-tooltip-template>
                                     <h5 class="font-bold mb-2">Magic Patterns</h5>
                                     <p>Magic Patterns are special patterns that can be used in the prompt to access character properties and current chatting log.</p>
                                     <p>Patterns start with <code>{|</code> and ends with <code>|}</code>. Inner text is command. Multi-line is supported.</p>
@@ -113,6 +113,19 @@ export function setupPromptModalEventListeners(app) {
   const modal = document.getElementById("prompt-modal-root");
   if (!modal) return;
 
+  if (window.lucide) {
+    window.lucide.createIcons();
+  }
+
+  let activeTooltip = null;
+
+  const removeTooltip = () => {
+    if (activeTooltip) {
+      activeTooltip.remove();
+      activeTooltip = null;
+    }
+  };
+
   modal.addEventListener("click", (e) => {
     if (
       e.target.id === "close-prompt-modal" ||
@@ -121,7 +134,59 @@ export function setupPromptModalEventListeners(app) {
     ) {
       app.setState({ showPromptModal: false });
     }
+    removeTooltip();
   });
+
+  document.querySelectorAll('.help-icon').forEach(icon => {
+    const group = icon.parentElement;
+    group.addEventListener('mouseenter', (e) => {
+        const template = group.querySelector('[data-tooltip-template]');
+        if (!template) return;
+
+        const iconElement = document.elementFromPoint(e.clientX, e.clientY);
+        if (!iconElement) return;
+
+        removeTooltip();
+
+        activeTooltip = document.createElement('div');
+        activeTooltip.innerHTML = template.innerHTML;
+        
+        const classes = template.className.replace('hidden', '').trim();
+        activeTooltip.className = classes;
+        
+        activeTooltip.style.position = 'fixed';
+        activeTooltip.style.zIndex = '100';
+        
+        document.body.appendChild(activeTooltip);
+
+        setTimeout(() => {
+            const iconRect = iconElement.getBoundingClientRect();
+            const tooltipRect = activeTooltip.getBoundingClientRect();
+
+            const isTopHalf = iconRect.top < window.innerHeight / 2;
+
+            if (isTopHalf) {
+                activeTooltip.style.top = `${iconRect.bottom + 5}px`;
+            } else {
+                activeTooltip.style.top = `${iconRect.top - tooltipRect.height - 5}px`;
+            }
+
+            let leftPosition = iconRect.left;
+            if (leftPosition + tooltipRect.width > window.innerWidth) {
+                leftPosition = window.innerWidth - tooltipRect.width - 5;
+            }
+            activeTooltip.style.left = `${leftPosition}px`;
+        }, 0);
+    });
+
+    group.addEventListener('mouseleave', removeTooltip);
+  });
+
+  const scrollableContent = modal.querySelector('.overflow-y-auto');
+  if (scrollableContent) {
+    scrollableContent.addEventListener('scroll', removeTooltip);
+  }
+
 
   document
     .getElementById("save-prompts-btn")

--- a/frontend/src/components/PromptModal.js
+++ b/frontend/src/components/PromptModal.js
@@ -143,14 +143,11 @@ export function setupPromptModalEventListeners(app) {
     activeTooltip.innerHTML = template.innerHTML;
     
     const classes = template.className.replace('hidden', '').trim();
-    activeTooltip.className = classes;
-    
-    activeTooltip.style.position = 'fixed';
-    activeTooltip.style.zIndex = '100';
+    activeTooltip.className = `${classes} fixed z-[100]`;
     
     document.body.appendChild(activeTooltip);
 
-    setTimeout(() => {
+    requestAnimationFrame(() => {
         const iconRect = iconElement.getBoundingClientRect();
         const tooltipRect = activeTooltip.getBoundingClientRect();
 
@@ -167,7 +164,7 @@ export function setupPromptModalEventListeners(app) {
             leftPosition = window.innerWidth - tooltipRect.width - 5;
         }
         activeTooltip.style.left = `${leftPosition}px`;
-    }, 0);
+    });
 
     if (isTouchEvent) {
         e.stopPropagation();


### PR DESCRIPTION
This PR fixes issue #51, where the tooltip in the prompt modal was not being displayed correctly.

The tooltip was being clipped by the modal's scrollable content area. This PR implements a JavaScript-based solution to dynamically create and position the tooltip, ensuring it appears correctly above or below the help icon, depending on its position in the viewport, and is not obscured by other modal elements.

Key changes:
- The tooltip is now created dynamically and appended to the body to escape the clipping container.
- Its position is calculated based on the icon's viewport coordinates.
- The tooltip is removed when the mouse leaves the icon, the content is scrolled, or the modal is closed.