### PR TITLE
feat(frontend): Add debug utility and dev tools

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ backend/ktlint
 
 # Local files
 TODO.md
+frontend/local/
 
 # Backup files
 *.backup

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -62,6 +62,22 @@
     lucide.createIcons();
   </script>
 
+  <script type="module" src="src/utils/debug-utils.ts"></script>
+  <script type="module">
+    import { initializeDebugUtility } from './src/utils/debug-utils.ts';
+    import { dumpLocalStorageToJson, dumpIndexedDBToJson } from './src/utils/dev-tools.ts';
+
+    initializeDebugUtility();
+
+    // Expose dev tools globally for easy access in console
+    if (import.meta.env.DEV) {
+      window.__dev__ = {
+        dumpLocalStorage: dumpLocalStorageToJson,
+        dumpIndexedDB: dumpIndexedDBToJson,
+      };
+      console.log("Dev tools (__dev__.dumpLocalStorage(), __dev__.dumpIndexedDB()) are available in the console.");
+    }
+  </script>
   <script type="module" src="src/index.js"></script>
   
 </body>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -62,22 +62,7 @@
     lucide.createIcons();
   </script>
 
-  <script type="module" src="src/utils/debug-utils.ts"></script>
-  <script type="module">
-    import { initializeDebugUtility } from './src/utils/debug-utils.ts';
-    import { dumpLocalStorageToJson, dumpIndexedDBToJson } from './src/utils/dev-tools.ts';
-
-    initializeDebugUtility();
-
-    // Expose dev tools globally for easy access in console
-    if (import.meta.env.DEV) {
-      window.__dev__ = {
-        dumpLocalStorage: dumpLocalStorageToJson,
-        dumpIndexedDB: dumpIndexedDBToJson,
-      };
-      console.log("Dev tools (__dev__.dumpLocalStorage(), __dev__.dumpIndexedDB()) are available in the console.");
-    }
-  </script>
+  <script type="module" src="src/dev-init.ts"></script>
   <script type="module" src="src/index.js"></script>
   
 </body>

--- a/frontend/src/dev-init.ts
+++ b/frontend/src/dev-init.ts
@@ -1,0 +1,15 @@
+// frontend/src/dev-init.ts
+
+import { initializeDebugUtility } from './utils/debug-utils.ts';
+import { dumpLocalStorageToJson, dumpIndexedDBToJson } from './utils/dev-tools.ts';
+
+initializeDebugUtility();
+
+// Expose dev tools globally for easy access in console
+if (import.meta.env.DEV) {
+  window.__dev__ = {
+    dumpLocalStorage: dumpLocalStorageToJson,
+    dumpIndexedDB: dumpIndexedDBToJson,
+  };
+  console.log("Dev tools (__dev__.dumpLocalStorage(), __dev__.dumpIndexedDB()) are available in the console.");
+}

--- a/frontend/src/utils/debug-utils.ts
+++ b/frontend/src/utils/debug-utils.ts
@@ -158,6 +158,7 @@ export async function loadPreconfiguredData(
  * Initializes the debug utility in development mode.
  * When running in a development environment (import.meta.env.DEV is true),
  * this function automatically clears all browser data and loads pre-configured data.
+*/
 export async function initializeDebugUtility(): Promise<void> {
   // Check if in development mode and if a debug flag is set (e.g., via localStorage or another env variable)
   // For now, we'll just use import.meta.env.DEV

--- a/frontend/src/utils/debug-utils.ts
+++ b/frontend/src/utils/debug-utils.ts
@@ -90,7 +90,7 @@ export async function loadPreconfiguredData(
         localStorageResponse.statusText,
       );
     }
-  } catch (error: any) {
+  } catch (error: unknown) {
     console.error("Error loading localStorage pre-configured data:", error);
   }
 
@@ -147,7 +147,7 @@ export async function loadPreconfiguredData(
         indexedDBResponse.statusText,
       );
     }
-  } catch (error: any) {
+  } catch (error) {
     console.error("Error loading IndexedDB pre-configured data:", error);
   }
 

--- a/frontend/src/utils/debug-utils.ts
+++ b/frontend/src/utils/debug-utils.ts
@@ -155,9 +155,9 @@ export async function loadPreconfiguredData(
 }
 
 /**
- * Initializes the debug utility based on a query parameter.
- * If `?debug=true` is present in the URL, it clears and loads data.
- */
+ * Initializes the debug utility in development mode.
+ * When running in a development environment (import.meta.env.DEV is true),
+ * this function automatically clears all browser data and loads pre-configured data.
 export async function initializeDebugUtility(): Promise<void> {
   // Check if in development mode and if a debug flag is set (e.g., via localStorage or another env variable)
   // For now, we'll just use import.meta.env.DEV

--- a/frontend/src/utils/debug-utils.ts
+++ b/frontend/src/utils/debug-utils.ts
@@ -1,0 +1,172 @@
+// frontend/src/utils/debug-utils.ts
+
+/**
+ * Clears all specified browser storage.
+ */
+export async function clearAllBrowserData(): Promise<void> {
+  console.log("Clearing all browser data...");
+
+  // Clear localStorage
+  localStorage.clear();
+  console.log("localStorage cleared.");
+
+  // Clear IndexedDB
+  const databases: IDBDatabaseInfo[] = await indexedDB.databases();
+  await Promise.all(
+    databases.map((db: IDBDatabaseInfo) => {
+      return new Promise<void>((resolve, reject) => {
+        if (!db.name) {
+          resolve(); // Skip if database name is undefined
+          return;
+        }
+        const request: IDBOpenDBRequest = indexedDB.deleteDatabase(db.name);
+        request.onsuccess = () => {
+          console.log(`IndexedDB database '${db.name}' deleted.`);
+          resolve();
+        };
+        request.onerror = (event: Event) => {
+          console.error(
+            `Error deleting IndexedDB database '${db.name}':`,
+            (event.target as IDBRequest).error,
+          );
+          reject((event.target as IDBRequest).error);
+        };
+      });
+    }),
+  );
+  console.log("IndexedDB cleared.");
+
+  // Clear cookies (this is more complex and often requires server-side or specific cookie paths)
+  // For client-side, we can try to expire them, but it's not foolproof.
+  document.cookie.split(";").forEach((c: string) => {
+    document.cookie = c
+      .replace(/^ +/, "")
+      .replace(/=.*/, "=;expires=" + new Date().toUTCString() + ";path=/");
+  });
+  console.log("Attempted to clear cookies.");
+
+  // Unregister service workers
+  if ("serviceWorker" in navigator) {
+    const registrations = await navigator.serviceWorker.getRegistrations();
+    await Promise.all(
+      registrations.map(async (registration: ServiceWorkerRegistration) => {
+        const success = await registration.unregister();
+        if (success) {
+          console.log("Service worker unregistered.");
+        } else {
+          console.error("Service worker unregistration failed.");
+        }
+        return success;
+      }),
+    );
+    console.log("Service workers unregistered.");
+  }
+  console.log("All browser data cleared successfully.");
+}
+
+/**
+ * Loads pre-configured data into browser storage.
+ * @param {string} localStoragePath - Path to the local storage JSON file.
+ * @param {string} indexedDBPath - Path to the IndexedDB JSON file.
+ */
+export async function loadPreconfiguredData(
+  localStoragePath: string,
+  indexedDBPath: string,
+): Promise<void> {
+  console.log("Loading pre-configured data...");
+
+  // Load localStorage data
+  try {
+    const localStorageResponse: Response = await fetch(localStoragePath);
+    if (localStorageResponse.ok) {
+      const data: { [key: string]: any } = await localStorageResponse.json();
+      for (const key in data) {
+        localStorage.setItem(key, JSON.stringify(data[key]));
+      }
+      console.log("localStorage pre-configured data loaded.");
+    } else {
+      console.warn(
+        `Could not load localStorage data from ${localStoragePath}:`,
+        localStorageResponse.statusText,
+      );
+    }
+  } catch (error: any) {
+    console.error("Error loading localStorage pre-configured data:", error);
+  }
+
+  // IndexedDB data loading
+  try {
+    const indexedDBResponse: Response = await fetch(indexedDBPath);
+    if (indexedDBResponse.ok) {
+      const dbData: { [dbName: string]: { data: { key: string; value: any }[] } } = await indexedDBResponse.json();
+
+      for (const dbName in dbData) {
+        const dataToLoad = dbData[dbName].data;
+
+        if (!dataToLoad || dataToLoad.length === 0) {
+          console.warn(`No data found for IndexedDB database '${dbName}'.`);
+          continue;
+        }
+
+        const request: IDBOpenDBRequest = indexedDB.open(dbName, 1); // Version 1, adjust if needed
+
+        request.onupgradeneeded = (event: IDBVersionChangeEvent) => {
+          const db: IDBDatabase = (event.target as IDBRequest).result;
+          // Assuming a single object store named 'data' with 'key' as keyPath
+          if (!db.objectStoreNames.contains('data')) {
+            db.createObjectStore('data', { keyPath: 'key' });
+          }
+        };
+
+        request.onsuccess = (event: Event) => {
+          const db: IDBDatabase = (event.target as IDBRequest).result;
+          const transaction: IDBTransaction = db.transaction(['data'], 'readwrite');
+          const objectStore: IDBObjectStore = transaction.objectStore('data');
+
+          dataToLoad.forEach(item => {
+            objectStore.put(item); // Use put to add or update
+          });
+
+          transaction.oncomplete = () => {
+            console.log(`IndexedDB database '${dbName}' loaded with pre-configured data.`);
+            db.close();
+          };
+          transaction.onerror = (transactionEvent: Event) => {
+            console.error(`Transaction error for '${dbName}':`, (transactionEvent.target as IDBRequest).error);
+            db.close();
+          };
+        };
+
+        request.onerror = (event: Event) => {
+          console.error(`Error opening IndexedDB database '${dbName}':`, (event.target as IDBRequest).error);
+        };
+      }
+    } else {
+      console.warn(
+        `Could not load IndexedDB data from ${indexedDBPath}:`,
+        indexedDBResponse.statusText,
+      );
+    }
+  } catch (error: any) {
+    console.error("Error loading IndexedDB pre-configured data:", error);
+  }
+
+  console.log("Pre-configured data loading complete.");
+}
+
+/**
+ * Initializes the debug utility based on a query parameter.
+ * If `?debug=true` is present in the URL, it clears and loads data.
+ */
+export async function initializeDebugUtility(): Promise<void> {
+  // Check if in development mode and if a debug flag is set (e.g., via localStorage or another env variable)
+  // For now, we'll just use import.meta.env.DEV
+  if (import.meta.env.DEV) {
+    console.log("Debug mode activated in development environment.");
+    await clearAllBrowserData();
+    await loadPreconfiguredData(
+      "/local/localstorage.json",
+      "/local/indexeddb.json",
+    );
+  }
+}

--- a/frontend/src/utils/dev-tools.ts
+++ b/frontend/src/utils/dev-tools.ts
@@ -73,7 +73,7 @@ export async function dumpIndexedDBToJson(): Promise<string | null> {
         const jsonOutput = JSON.stringify(indexedDBData, null, 2);
         console.log("IndexedDB data dumped:\n", jsonOutput);
         return jsonOutput;
-    } catch (error: any) {
+    } catch (error: unknown) {
         console.error("Error dumping IndexedDB:", error);
         return null;
     }

--- a/frontend/src/utils/dev-tools.ts
+++ b/frontend/src/utils/dev-tools.ts
@@ -1,0 +1,80 @@
+// frontend/src/utils/dev-tools.ts
+
+/**
+ * Dumps all localStorage data to a JSON string.
+ * @returns {string} JSON string of localStorage data.
+ */
+export function dumpLocalStorageToJson(): string {
+    const localStorageData: { [key: string]: any } = {};
+    for (let i = 0; i < localStorage.length; i++) {
+        const key = localStorage.key(i);
+        if (key) {
+            try {
+                localStorageData[key] = JSON.parse(localStorage.getItem(key) || 'null');
+            } catch (e) {
+                localStorageData[key] = localStorage.getItem(key);
+            }
+        }
+    }
+    const jsonOutput = JSON.stringify(localStorageData, null, 2);
+    console.log("localStorage data dumped:\n", jsonOutput);
+    return jsonOutput;
+}
+
+/**
+ * Dumps all IndexedDB data to a JSON string.
+ * This is a generic script and might need adjustments based on the specific IndexedDB structure.
+ * @returns {Promise<string | null>} JSON string of IndexedDB data, or null if an error occurs.
+ */
+export async function dumpIndexedDBToJson(): Promise<string | null> {
+    const indexedDBData: { [dbName: string]: { [storeName: string]: any[] } } = {};
+
+    async function dumpDatabase(dbName: string): Promise<void> {
+        return new Promise((resolve, reject) => {
+            const request: IDBOpenDBRequest = indexedDB.open(dbName);
+            request.onsuccess = (event: Event) => {
+                const db: IDBDatabase = (event.target as IDBRequest).result;
+                indexedDBData[dbName] = {};
+
+                const transaction: IDBTransaction = db.transaction(db.objectStoreNames, 'readonly');
+                transaction.oncomplete = () => {
+                    db.close();
+                    resolve();
+                };
+                transaction.onerror = (event: Event) => {
+                    console.error(`Transaction error for ${dbName}:`, (event.target as IDBRequest).error);
+                    db.close();
+                    reject((event.target as IDBRequest).error);
+                };
+
+                for (const storeName of db.objectStoreNames) {
+                    indexedDBData[dbName][storeName] = [];
+                    const objectStore: IDBObjectStore = transaction.objectStore(storeName);
+                    objectStore.openCursor().onsuccess = (event: Event) => {
+                        const cursor: IDBCursorWithValue = (event.target as IDBRequest).result;
+                        if (cursor) {
+                            indexedDBData[dbName][storeName].push(cursor.value);
+                            cursor.continue();
+                        }
+                    };
+                }
+            };
+            request.onerror = (event: Event) => {
+                console.error(`Error opening IndexedDB database ${dbName}:`, (event.target as IDBRequest).error);
+                reject((event.target as IDBRequest).error);
+            };
+        });
+    }
+
+    try {
+        const databases: IDBDatabaseInfo[] = await indexedDB.databases();
+        const dumpPromises = databases.map(db => db.name ? dumpDatabase(db.name) : Promise.resolve());
+        await Promise.all(dumpPromises);
+        const jsonOutput = JSON.stringify(indexedDBData, null, 2);
+        console.log("IndexedDB data dumped:\n", jsonOutput);
+        return jsonOutput;
+    } catch (error: any) {
+        console.error("Error dumping IndexedDB:", error);
+        return null;
+    }
+}

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -39,7 +39,7 @@
     ], /* Specify type package names to be included without being referenced in a source file. */
     // "allowUmdGlobalAccess": true,                     /* Allow accessing UMD globals from modules. */
     // "moduleSuffixes": [],                             /* List of file name suffixes to search when resolving a module. */
-    // "allowImportingTsExtensions": true,               /* Allow imports to include TypeScript file extensions. Requires '--moduleResolution bundler' and either '--noEmit' or '--emitDeclarationOnly' to be set. */
+    "allowImportingTsExtensions": true, /* Allow imports to include TypeScript file extensions. Requires '--moduleResolution bundler' and either '--noEmit' or '--emitDeclarationOnly' to be set. */
     // "rewriteRelativeImportExtensions": true,          /* Rewrite '.ts', '.tsx', '.mts', and '.cts' file extensions in relative import paths to their JavaScript equivalent in output files. */
     // "resolvePackageJsonExports": true,                /* Use the package.json 'exports' field when resolving package imports. */
     // "resolvePackageJsonImports": true,                /* Use the package.json 'imports' field when resolving imports. */
@@ -58,7 +58,7 @@
     // "emitDeclarationOnly": true,                      /* Only output d.ts files and not JavaScript files. */
     "sourceMap": true, /* Create source map files for emitted JavaScript files. */
     // "inlineSourceMap": true,                          /* Include sourcemap files inside the emitted JavaScript. */
-    // "noEmit": true,                                   /* Disable emitting files from a compilation. */
+    "noEmit": true, /* Disable emitting files from a compilation. */
     // "outFile": "./",                                  /* Specify a file that bundles all outputs into one JavaScript file. If 'declaration' is true, also designates a file that bundles all .d.ts output. */
     "outDir": "./dist", /* Specify an output folder for all emitted files. */
     // "removeComments": true,                           /* Disable emitting comments. */

--- a/frontend/vite-env.d.ts
+++ b/frontend/vite-env.d.ts
@@ -1,0 +1,18 @@
+/// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  readonly VITE_APP_TITLE: string
+  // more env variables...
+  readonly DEV: boolean; // Explicitly define DEV
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv
+}
+
+interface Window {
+  __dev__?: {
+    dumpLocalStorage: () => string;
+    dumpIndexedDB: () => Promise<string | null>;
+  };
+}

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -28,6 +28,8 @@ const prodOnlyPlugin = [
     })
 ]
 export default defineConfig(({ mode }) => ({
+    // import.meta.env.DEV is automatically set by Vite based on the 'mode'.
+    // It is true in development (pnpm dev:fe) and false in production (pnpm build:fe).
     server: {
         open: "index.html",
     },


### PR DESCRIPTION
This PR introduces a debug utility for the frontend, allowing developers to clear and pre-configure browser storage (localStorage and IndexedDB) automatically in development mode. It also exposes global developer tools (`__dev__.dumpLocalStorage()` and `__dev__.dumpIndexedDB()`) for easy data dumping from the browser console.

## Checklist

- [x] I have tested my changes locally.
- [x] I have updated the documentation...
- [x] and docstrings(JSDoc or KDoc).
- [x] I've also checked the code for any linting error/warnings.
- [x] I formatted the code with the formatter.

## Additional Notes

This feature is intended for development purposes only and is activated automatically when `import.meta.env.DEV` is true. The `frontend/local/` directory is now gitignored to prevent sensitive data from being committed.