### PR TITLE
Add workflow for flaky test stress testing

### DIFF
--- a/.github/workflows/flacky_test_check.yml
+++ b/.github/workflows/flacky_test_check.yml
@@ -1,0 +1,61 @@
+name: Flaky Test Stress Test
+
+on:
+  workflow_dispatch:
+    inputs:
+      iterations:
+        description: |
+          Number of parallel iterations to run.
+          Note that iteration above 20 requires GitHub Pro or better to run in parallel.
+        required: true
+        default: 10
+        type: number
+
+jobs:
+  setup-matrix:
+    runs-on: ubuntu-latest
+    outputs:
+      indices: ${{ steps.set-matrix.outputs.indices }}
+    steps:
+      - id: set-matrix
+        run: |
+          ITER=$(echo "${{ github.event.inputs.iterations }}")
+          # Generate a JSON array [1, 2, ..., N]
+          INDICES=$(node -e "console.log(JSON.stringify(Array.from({length: $ITER}, (_, i) => i + 1)))")
+          echo "indices=$INDICES" >> $GITHUB_OUTPUT
+
+  run-flaky-check:
+    needs: setup-matrix
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false # Don't stop other jobs if one fails, we want to see all fails
+      matrix:
+        index: ${{ fromJson(needs.setup-matrix.outputs.indices) }}
+    container: 
+      image: mcr.microsoft.com/playwright:v1.57.0
+      options: --user 1001
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          package_json_file: "package.json"
+          run_install: false
+
+      - name: Install Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: "package.json"
+          cache: "pnpm"
+          cache-dependency-path: "pnpm-lock.yaml"
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run Tests (Iteration ${{ matrix.index }})
+        run: |
+            pnpm -F frontend test:browser
+            pnpm -F frontend test:coverage
+            pnpm -F frontend test
+        timeout-minutes: 5


### PR DESCRIPTION

## Description

This pull request introduces a new GitHub Actions workflow to help identify flaky browser tests by running them repeatedly in parallel. The workflow allows users to specify the number of iterations and leverages a matrix strategy to execute multiple test runs concurrently, improving the reliability of test results.

Testing improvements:

* Added a new workflow file `.github/workflows/flacky_test_check.yml` that defines a stress test for flaky tests, allowing users to specify the number of parallel iterations to run via workflow dispatch inputs.
* Utilizes a matrix strategy to run multiple test jobs in parallel, each executing browser tests, coverage checks, and general frontend tests, with a configurable timeout for each iteration.
* Uses the official Playwright container image for consistent browser testing environments and sets up Node.js and pnpm for dependency management.

## Checklist

If these questions do not apply to your pull request, just check them.

- [x] I have tested my changes locally.
- [x] I have updated the documentation...
- [x] and JSDoc.
- [x] I've also checked the code for any linting error/warnings.
- [x] I formatted the code with the formatter.

## Additional Notes

It's for checking #141's flaky test.