### PR TITLE
ci: Add workflow for flaky test stress testing

### DIFF
--- a/.github/workflows/flacky_test_check.yml
+++ b/.github/workflows/flacky_test_check.yml
@@ -1,0 +1,61 @@
+name: Flaky Test Stress Test
+
+on:
+  workflow_dispatch:
+    inputs:
+      iterations:
+        description: |
+          Number of parallel iterations to run.
+          Note that iteration above 20 requires GitHub Pro or better to run in parallel.
+        required: true
+        default: 10
+        type: number
+
+jobs:
+  setup-matrix:
+    runs-on: ubuntu-latest
+    outputs:
+      indices: ${{ steps.set-matrix.outputs.indices }}
+    steps:
+      - id: set-matrix
+        run: |
+          ITER=$(echo "${{ github.event.inputs.iterations }}")
+          # Generate a JSON array [1, 2, ..., N]
+          INDICES=$(node -e "console.log(JSON.stringify(Array.from({length: $ITER}, (_, i) => i + 1)))")
+          echo "indices=$INDICES" >> $GITHUB_OUTPUT
+
+  run-flaky-check:
+    needs: setup-matrix
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false # Don't stop other jobs if one fails, we want to see all fails
+      matrix:
+        index: ${{ fromJson(needs.setup-matrix.outputs.indices) }}
+    container: 
+      image: mcr.microsoft.com/playwright:v1.57.0
+      options: --user 1001
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          package_json_file: "package.json"
+          run_install: false
+
+      - name: Install Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: "package.json"
+          cache: "pnpm"
+          cache-dependency-path: "pnpm-lock.yaml"
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run Tests (Iteration ${{ matrix.index }})
+        run: |
+            pnpm -F frontend test:browser
+            pnpm -F frontend test:coverage
+            pnpm -F frontend test
+        timeout-minutes: 5

--- a/.github/workflows/flacky_test_check.yml
+++ b/.github/workflows/flacky_test_check.yml
@@ -6,7 +6,7 @@ on:
       iterations:
         description: |
           Number of parallel iterations to run.
-          Note that iteration above 20 requires GitHub Pro or better to run in parallel.
+          Note that iterations above 20 require GitHub Pro or better to run in parallel.
         required: true
         default: 10
         type: number
@@ -19,7 +19,7 @@ jobs:
     steps:
       - id: set-matrix
         run: |
-          ITER=$(echo "${{ github.event.inputs.iterations }}")
+          ITER="${{ github.event.inputs.iterations }}"
           # Generate a JSON array [1, 2, ..., N]
           INDICES=$(node -e "console.log(JSON.stringify(Array.from({length: $ITER}, (_, i) => i + 1)))")
           echo "indices=$INDICES" >> $GITHUB_OUTPUT
@@ -27,6 +27,7 @@ jobs:
   run-flaky-check:
     needs: setup-matrix
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     strategy:
       fail-fast: false # Don't stop other jobs if one fails, we want to see all fails
       matrix:
@@ -58,4 +59,4 @@ jobs:
             pnpm -F frontend test:browser
             pnpm -F frontend test:coverage
             pnpm -F frontend test
-        timeout-minutes: 5
+        timeout-minutes: 20

--- a/.github/workflows/flaky_test_check.yml
+++ b/.github/workflows/flaky_test_check.yml
@@ -7,6 +7,7 @@ on:
         description: |
           Number of parallel iterations to run.
           Note that iterations above 20 require GitHub Pro or better to run in parallel.
+          Range: 1..200
         required: true
         default: 10
         type: number
@@ -20,6 +21,10 @@ jobs:
       - id: set-matrix
         run: |
           ITER="${{ github.event.inputs.iterations }}"
+          if [ "$ITER" -lt 1 ] || [ "$ITER" -gt 200 ]; then
+            echo "Error: iterations must be between 1 and 200."
+            exit 1
+          fi
           # Generate a JSON array [1, 2, ..., N]
           INDICES=$(node -e "console.log(JSON.stringify(Array.from({length: $ITER}, (_, i) => i + 1)))")
           echo "indices=$INDICES" >> $GITHUB_OUTPUT
@@ -57,6 +62,6 @@ jobs:
       - name: Run Tests (Iteration ${{ matrix.index }})
         run: |
             pnpm -F frontend test:browser
-            pnpm -F frontend test:coverage
+            pnpm -F frontend test:coverage --coverage.reporters=text-summary
             pnpm -F frontend test
-        timeout-minutes: 20
+        timeout-minutes: 10

--- a/.github/workflows/flaky_test_check.yml
+++ b/.github/workflows/flaky_test_check.yml
@@ -11,7 +11,8 @@ on:
         required: true
         default: 10
         type: number
-
+permissions:
+  contents: read
 jobs:
   setup-matrix:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Description

This pull request introduces a new GitHub Actions workflow to enable stress testing for flaky tests by running multiple parallel test iterations. The workflow is configurable, allowing users to specify the number of iterations and leverages a matrix strategy to execute tests in parallel containers.

**New workflow for flaky test stress testing:**

* Added `.github/workflows/flacky_test_check.yml` to define a reusable workflow that runs browser, coverage, and general frontend tests in parallel, based on a user-specified number of iterations.
* Implements a matrix job setup to dynamically generate and run the specified number of iterations, supporting up to 20 parallel jobs (with higher limits for GitHub Pro or better).
* Uses the Playwright container image to ensure a consistent test environment for each parallel job.
* Installs dependencies with `pnpm` and sets up Node.js caching for efficient test runs.
* Configures the workflow to not fail fast, allowing all parallel jobs to complete and report results even if some fail.

## Checklist

If these questions do not apply to your pull request, just check them.

- [ ] I have tested my changes locally.
- [ ] I have updated the documentation...
- [ ] and JSDoc.
- [ ] I've also checked the code for any linting error/warnings.
- [ ] I formatted the code with the formatter.

## Additional Notes

It's for checking #121's flaky test.  #122 is closed by mistake.
